### PR TITLE
client.shared.test.js - Fixed unit test failures

### DIFF
--- a/client.shared.test.js/src/StringFactory/StringFactory.test.ts
+++ b/client.shared.test.js/src/StringFactory/StringFactory.test.ts
@@ -1,13 +1,14 @@
 ﻿import { expect } from "chai";
 
 // If moduleResolution is node
-import { createInstance } from "client.shared";
+import { createInstance } from "client.shared/debug/client.shared";
 // If moduleResolution is classic
 // import { createInstance } from "../../node_modules/client.shared/client.shared";
 
 describe("StringFactory", () => {
     it("Make sure StringFactory exists", () => {
         let instance = createInstance({
+            ENVIRONMENT: 'WEB',
             onRuntimeInitialized: () => {
             },
             locateFile: function(filename) {
@@ -22,6 +23,7 @@ describe("StringFactory", () => {
     });
     it("GetString", () => {
         let instance = createInstance({
+            ENVIRONMENT: 'WEB',
             onRuntimeInitialized: () => {
             },
             locateFile: function(filename) {
@@ -39,6 +41,7 @@ describe("StringFactory", () => {
     });
     it("GetString twice returns different strings", () => {
         let instance = createInstance({
+            ENVIRONMENT: 'WEB',
             onRuntimeInitialized: () => {
             },
             locateFile: function(filename) {

--- a/client.shared.test.js/src/StringFactory/StringFactory.test.ts
+++ b/client.shared.test.js/src/StringFactory/StringFactory.test.ts
@@ -1,14 +1,16 @@
 ﻿import { expect } from "chai";
 
 // If moduleResolution is node
-import { createInstance } from "client.shared/debug/client.shared";
+import { ClientShared } from "client.shared";
+import { createInstance } from "client.shared/debug/client.shared"; // Seems if you get createInstance from client.shared, there are issues loading the mem file
 // If moduleResolution is classic
 // import { createInstance } from "../../node_modules/client.shared/client.shared";
 
 describe("StringFactory", () => {
-    it("Make sure StringFactory exists", () => {
-        let instance = createInstance({
-            ENVIRONMENT: 'WEB',
+    let instance: ClientShared;
+    beforeEach(() => {
+        instance = createInstance({
+            ENVIRONMENT:"WEB",
             onRuntimeInitialized: () => {
             },
             locateFile: function(filename) {
@@ -17,40 +19,22 @@ describe("StringFactory", () => {
                 }                
             },
         });
+    });
 
+    it("Make sure StringFactory exists", () => {
         expect(instance).to.exist;
         expect(instance.StringFactory).to.exist;
     });
-    it("GetString", () => {
-        let instance = createInstance({
-            ENVIRONMENT: 'WEB',
-            onRuntimeInitialized: () => {
-            },
-            locateFile: function(filename) {
-                if (filename === 'client.shared.js.mem') {
-                    return "node_modules/client.shared/ship/client.shared.js.mem"
-                }                
-            },
-        });
 
+    it("GetString", () => {
         let stringFactory = new instance.StringFactory();
         expect(stringFactory.getString).to.exist;
         let string_0 = stringFactory.getString();
         expect(string_0).to.not.be.empty;
         expect(string_0).to.contain(0);
     });
-    it("GetString twice returns different strings", () => {
-        let instance = createInstance({
-            ENVIRONMENT: 'WEB',
-            onRuntimeInitialized: () => {
-            },
-            locateFile: function(filename) {
-                if (filename === 'client.shared.js.mem') {
-                    return "node_modules/client.shared/ship/client.shared.js.mem"
-                }                
-            },
-        });
 
+    it("GetString twice returns different strings", () => {
         let stringFactory = new instance.StringFactory();
         expect(stringFactory.getString).to.exist;
         let string_0 = stringFactory.getString();

--- a/client.shared.test.js/tsconfig.json
+++ b/client.shared.test.js/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "outDir": "./app/",
+    "outDir": "./dist/",
     "sourceMap": true,
-    "target": "es5",
+    "target": "es6",
     "module": "umd",
     "moduleResolution": "node",
     "noEmitOnError": false,
@@ -18,7 +18,6 @@
     "chai",
     "expect"
   ],
-  "version": "2.4.1",
   "include": [
     "src/**/*.ts"
   ],

--- a/client.shared.test.js/tsconfig.json
+++ b/client.shared.test.js/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "sourceMap": true,
-    "target": "es6",
+    "target": "es5",
     "module": "umd",
     "moduleResolution": "node",
     "noEmitOnError": false,


### PR DESCRIPTION
Seems we need to specify the environment for these unit tests to run. If we don't the test runs in the shell environment and emscripten sets the print variable incorrectly.